### PR TITLE
Fix error: persons with only one publication would fail to be parsed

### DIFF
--- a/dblp-person.js
+++ b/dblp-person.js
@@ -27,7 +27,7 @@ class DBLPPerson {
     if (validation.error === null) {
       this.dblpperson = rawJSON.dblpperson;
       this.person = DBLPPerson.getFirstElement(this.dblpperson.person);
-      this.r = this.dblpperson.r;
+      this.r = util.isArray(this.dblpperson.r) ? this.dblpperson.r : [this.dblpperson.r];
       this.coauthors = this.dblpperson.coauthors;
     } else {
       throw new Error(`[DBLPPerson constructor] Schema error - ${validation.error}`);

--- a/dblp-schema.js
+++ b/dblp-schema.js
@@ -93,7 +93,7 @@ const rSchema = Joi.array().items(
     'person',
     'data',
   ).required(),
-).required();
+).single().required();
 
 
 /**


### PR DESCRIPTION
Currently, schema validation and getting publications fails if a person has only one publication. This is a simple fix for this issue.